### PR TITLE
7101-api-example-v3 => master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-This repo contains example scripts for using the Ordoro API. Check out [the complete API documentation](http://docs.ordoro.apiary.io/) for more information. There's also [a ruby gem](https://github.com/geminimvp/ordoro-ruby) available.
+This repo contains example scripts for using the Ordoro API.
+- Check out [the complete API documentation](http://docs.ordoro.apiary.io/) for more information.
+- And the [v3 Orders API](https://devapiverson.docs.apiary.io) for any order related actions.
+
+__NOTE__ Orders will use a different version of the API, but all other actions will use the base API and documentation.
 
 ***
 
@@ -6,7 +10,8 @@ This repo contains example scripts for using the Ordoro API. Check out [the comp
 
 #### Authentication
 
-We use basic auth. Your username can be found under settings->users in your Ordoro account.
+We use Basic Auth.
+You can generate API Keys under Settings->API Keys in your Ordoro account and use them accordingly.
 
 #### Format
 
@@ -19,7 +24,7 @@ JSON in, JSON out
 ### Getting new orders
 
 ```sh
-curl --user 'myusername:mypassword' --header 'Content-Type: application/json' https://api.ordoro.com/order/?status=new
+curl --user 'myusername:mypassword' --header 'Content-Type: application/json' https://api.ordoro.com/order?status=awaiting_fulfillment
 ```
 
 ### Getting products
@@ -39,26 +44,85 @@ __NOTE__ When we import an order, we automatically decrease the available on han
 curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --request PUT --data '{"on_hand":99}' https://api.ordoro.com/product/:sku/warehouse/:warehouse_id/
 ```
 
-### Save tracking number
-
-You must first create a shipment. Using this endpoint, we’ll automatically put the order lines into the shipment that have enough inventory to be fulfilled. You can then modify the shipment lines if necessary. You can also create a shipment directly if that’s more convenient.
-
-```sh
-curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --request POST https://api.ordoro.com/order/:order_id/create_shipment/
-```
-
-```sh
-curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --request PUT --data '{"quantity":99}' https://api.ordoro.com/shipment/:shipment_id/line/:line_id/
-```
-
-```sh
-curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --request POST --data '{"notify_cart":true, "tracking":{"shipping_method: "fast","tracking":91728387,"vendor":"UPS","cost":55}}' https://api.ordoro.com/shipment/:shipment_id/tracking/
-```
-
 ### Create order
 
 ```sh
-curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --request POST --data '{"order_id": "unique-order-id", "billing_address": {"name": "Frank"}, "shipping_address": {"name": "John"}}' https://api.ordoro.com/order/
+curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --request POST https://api.ordoro.com/v3/order --data '{
+  "billing_address": {
+    "city": "austin",
+    "country": "USA",
+    "email": "mrgattispizza@delivers.com",
+    "name": "James Eure",
+    "phone": "4592222",
+    "state": "tx",
+    "street1": "123 foo-bar ln",
+    "zip": "78701"
+  },
+  "cart": 100,
+  "cart_order_id": "thats-some-funky-1234",
+  "grand_total": 123.45,
+  "lines": [
+    {
+      "cart_orderitem_id": "abc.123",
+      "product": {
+        "amazon_extra_info": {
+          "asin": "55555",
+          "listing_id": "12356",
+          "pending_quantity": 4
+        },
+        "cost": 1.69,
+        "name": "special product name",
+        "price": 69.69,
+        "sku": "sku1",
+        "taxable": "false",
+        "weight": 1.0
+      },
+      "quantity": 2
+    },
+    {
+      "cart_orderitem_id": "abc.456",
+      "product": {
+        "cost": 3.45,
+        "name": "Plastic Toy",
+        "price": 1.23,
+        "sku": "sku2",
+        "taxable": "false",
+        "weight": 2.0
+      },
+      "quantity": 1
+    }
+  ],
+  "order_date": "2015-12-09T12:01:00.855700",
+  "order_id": "order-1234",
+  "product_amount": 100.1,
+  "shipping_address": {
+    "city": "austin",
+    "country": "USA",
+    "email": "jenny@igotyournumber.com",
+    "name": "Tommy Tutone",
+    "phone": "8675309",
+    "state": "tx",
+    "street1": "123 foo-bar ln",
+    "zip": "78701"
+  },
+  "tags": [
+    {
+      "color": "#FFFFFF",
+      "text": "Unpaid"
+    },
+    {
+      "color": "#C0C0C0",
+      "text": "Alert"
+    }
+  ],
+  "tax_amount": 1.23
+}'
+```
+
+### Save tracking number
+
+```sh
+curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --request POST --data '{"tracking_number": "1234-lkjd", "cost": 7.00, "ship_date": "2016-03-07T06:06:06.123456-06:00", "shipping_method": "rail", "carrier_name": "DHL", "notify_bill_to": false, "notify_ship_to": true, "notify_cart": true}' https://api.ordoro.com/v3/order/:order_number/shipping_info
 ```
 
 ### Create product
@@ -69,8 +133,8 @@ curl --user 'myusername:mypassword' --header 'Content-Type: application/json' --
 
 ### Get tracking information
 
-The tracking information is stored in the tracking field of the shipment
+The tracking information is stored in the shipping_info field of the order.
 
 ```sh
-curl --user 'myusername:mypassword' https://api.ordoro.com/shipment/:shipment_id/
+curl --user 'myusername:mypassword' https://api.ordoro.com/v3/order/:order_number
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ JSON in, JSON out
 ### Getting new orders
 
 ```sh
-curl --user 'myusername:mypassword' --header 'Content-Type: application/json' https://api.ordoro.com/order?status=awaiting_fulfillment
+curl --user 'myusername:mypassword' --header 'Content-Type: application/json' https://api.ordoro.com/v3/order?status=awaiting_fulfillment
 ```
 
 ### Getting products


### PR DESCRIPTION
### Update Readme for v3

- Remove shipments and include references to the v3 Orders API documentation for further reference.
- Include API Keys information since we now allow this.
- Remove ruby gem reference as it is not Ordoro v3 compliant.

ordoro/ordoro#7101

ordoro/api-examples@6c58c3aea23fb23a3c7e436ec9f71d8edad5cbcc

___

### missed a spot - v3 order

ordoro/api-examples@d5e58fa64a2fe768c00fcef7260806edbc6c79a6